### PR TITLE
Allow ApolloTracing.start_proxy to accept a JSON string.

### DIFF
--- a/lib/apollo_tracing.rb
+++ b/lib/apollo_tracing.rb
@@ -4,8 +4,13 @@ require "graphql"
 require "apollo_tracing/version"
 
 class ApolloTracing
-  def self.start_proxy(config_filepath = 'config/apollo-engine.json')
-    config_json = File.read(config_filepath)
+  def self.start_proxy(config_filepath_or_json = 'config/apollo-engine.json')
+    config_json =
+      if File.exist?(config_filepath_or_json)
+        File.read(config_filepath_or_json)
+      else
+        config_filepath_or_json
+      end
     binary_path =
       if RUBY_PLATFORM.include?('darwin')
         File.expand_path('../../bin/engineproxy_darwin_amd64', __FILE__)

--- a/spec/apollo_tracing_spec.rb
+++ b/spec/apollo_tracing_spec.rb
@@ -11,6 +11,13 @@ RSpec.describe ApolloTracing do
       expect { Process.getpgid(pid) }.not_to raise_error
       ApolloTracing.stop_proxy
     end
+
+    it 'runs a proxy with a given JSON instead of a file path' do
+      config_json = File.read('spec/fixtures/apollo-engine-proxy.json')
+      pid = ApolloTracing.start_proxy(config_json)
+      expect { Process.getpgid(pid) }.not_to raise_error
+      ApolloTracing.stop_proxy
+    end
   end
 
   describe '.stop_proxy' do


### PR DESCRIPTION
This allows us to create a JSON string on the fly when starting server, customizing this behavior on runtime using i.e. environment variables to build the JSON out, for instance.