### PR TITLE
after_query: avoid trying to instrument failed query results

### DIFF
--- a/lib/apollo_tracing.rb
+++ b/lib/apollo_tracing.rb
@@ -60,7 +60,7 @@ class ApolloTracing
 
   def after_query(query)
     result = query.result
-    return unless result
+    return if result.to_h.nil?
     end_time = Time.now.utc
     duration_nanos = duration_nanos(start_time: query.context['apollo-tracing']['start_time'], end_time: end_time)
 

--- a/lib/apollo_tracing.rb
+++ b/lib/apollo_tracing.rb
@@ -60,7 +60,7 @@ class ApolloTracing
 
   def after_query(query)
     result = query.result
-    return if result.to_h.nil?
+    return if result.nil? || result.to_h.nil?
     end_time = Time.now.utc
     duration_nanos = duration_nanos(start_time: query.context['apollo-tracing']['start_time'], end_time: end_time)
 

--- a/lib/apollo_tracing.rb
+++ b/lib/apollo_tracing.rb
@@ -60,6 +60,7 @@ class ApolloTracing
 
   def after_query(query)
     result = query.result
+    return unless result
     end_time = Time.now.utc
     duration_nanos = duration_nanos(start_time: query.context['apollo-tracing']['start_time'], end_time: end_time)
 

--- a/spec/apollo_tracing_spec.rb
+++ b/spec/apollo_tracing_spec.rb
@@ -3,6 +3,7 @@ require "spec_helper"
 require 'fixtures/user'
 require 'fixtures/post'
 require 'fixtures/schema'
+require 'fixtures/broken_schema'
 
 RSpec.describe ApolloTracing do
   describe '.start_proxy' do
@@ -29,6 +30,14 @@ RSpec.describe ApolloTracing do
   end
 
   context 'introspection' do
+    it 'supports a nil result for failures' do
+      query = 'query($user_id: ID!) { posts(user_id: $user_id) { id title user_id } }'
+
+      expect {
+        BrokenSchema.execute(query, variables: { 'user_id' => '1' })
+      }.to raise_error(NoMethodError, /undefined method `title' for/)
+    end
+
     it 'returns time in RFC 3339 format' do
       query = "query($user_id: ID!) { posts(user_id: $user_id) { id title user_id } }"
       now = Time.new(2017, 8, 25, 0, 0, 0, '+00:00')

--- a/spec/fixtures/broken_schema.rb
+++ b/spec/fixtures/broken_schema.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'ostruct'
+
+BadPostType = GraphQL::ObjectType.define do
+  name 'Foo'
+  description 'See also PostType, for a working version of this'
+
+  field :id, !types.String, hash_key: :id
+  field :user_id, !types.String, hash_key: :user_id
+  field :title, !types.String # This is the intended broken-ness: missing a hash_key setting
+end
+
+BrokenQueryType = GraphQL::ObjectType.define do
+  name 'BrokenQuery'
+  description 'See also QueryType, for a working version of this'
+  field :posts, !types[!BadPostType] do
+    argument :user_id, !types.ID
+    resolve ->(_obj, _args, _ctx) {
+      [ { id: 'foo1', title: 'titel1', user_id: 'Sven'} ]
+    }
+  end
+end
+
+BrokenSchema = GraphQL::Schema.define do
+  query BrokenQueryType
+  use ApolloTracing.new
+end


### PR DESCRIPTION
This PR adds an early return to the `after_query`: if `query.result` is `nil`, this method will otherwise raise a `NoMethodError`.

This could happen if something broke "before getting here".

Benefit: the user will not begin suspecting this gem of being the culprit.

Question for reviewer: Would a log message such as "[apollo-tracing] No result to instrument!" be useful?