### PR TITLE
Update apollo-engine-js to version 2018.02-2-g0b77ff3e3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PROXY_VERSION := 2017.11-40-g9585bfc6
+PROXY_VERSION := 2018.02-2-g0b77ff3e3
 
 download_binaries:
 	curl -O https://registry.npmjs.org/apollo-engine-binary-darwin/-/apollo-engine-binary-darwin-0.$(PROXY_VERSION).tgz


### PR DESCRIPTION
## Why?
- There are some old bug that has been discovered and fixed for `apollo-engine-js` which still an issue with `apollo-tracing-ruby` because we are still using an old version from Nov 2017.
- Related issues: https://github.com/uniiverse/apollo-tracing-ruby/issues/8


## How?
By update `apollo-engine-js` dependency to a up-to-date version, currently `2018.02-2-g0b77ff3e3` is the latest stable version.

## How this was tested?
- Manually build `bin/setup`, binary files was built successfully in `bin` folder 