### PR TITLE
Update bundled version of the Engine proxy to 1.1.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PROXY_VERSION := 2018.02-2-g0b77ff3e3
+PROXY_VERSION := 2018.4-20-g7a8822c14
 
 download_binaries:
 	curl -O https://registry.npmjs.org/apollo-engine-binary-darwin/-/apollo-engine-binary-darwin-0.$(PROXY_VERSION).tgz


### PR DESCRIPTION
Hi uniiverse folks! Thanks for helping Ruby users use our proxy.

The version you're currently shipping is a few months out of date.  If you take this PR and then release it, it should be much closer to the present.

I'd like to do some work to make it easier for you to take updates (eg, make the binaries available under the pretty 1.0.6-style version numbers that we publish release notes about) but this should be a start.