### PR TITLE
CI: Use latest 2.3 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
-sudo: false
 language: ruby
 rvm:
-  - 2.3.4
+  - 2.3.8
 script: make download_binaries && bundle exec rspec

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ PROXY_VERSION := 2018.4-20-g7a8822c14
 
 download_binaries:
 	curl -O https://registry.npmjs.org/apollo-engine-binary-darwin/-/apollo-engine-binary-darwin-0.$(PROXY_VERSION).tgz
-	curl -O https://registry.npmjs.org/apollo-engine-binary-darwin/-/apollo-engine-binary-linux-0.$(PROXY_VERSION).tgz
-	curl -O https://registry.npmjs.org/apollo-engine-binary-darwin/-/apollo-engine-binary-windows-0.$(PROXY_VERSION).tgz
+	curl -O https://registry.npmjs.org/apollo-engine-binary-linux/-/apollo-engine-binary-linux-0.$(PROXY_VERSION).tgz
+	curl -O https://registry.npmjs.org/apollo-engine-binary-windows/-/apollo-engine-binary-windows-0.$(PROXY_VERSION).tgz
 	tar -xzf apollo-engine-binary-darwin-0.$(PROXY_VERSION).tgz
 	tar -xzf apollo-engine-binary-linux-0.$(PROXY_VERSION).tgz
 	tar -xzf apollo-engine-binary-windows-0.$(PROXY_VERSION).tgz


### PR DESCRIPTION
This PR updates the CI matrix.

  - Also: Removes an old setting from Travis. See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

PS: 2.3 is going out of support, soon, consider using 2.6.2.

Also: Edited the `Makefile` to make it work better. [This made the build pass.](https://travis-ci.org/uniiverse/apollo-tracing-ruby/builds/514342723)